### PR TITLE
Reduce left and right margins on Trending component

### DIFF
--- a/src/components/Trending.js
+++ b/src/components/Trending.js
@@ -8,7 +8,7 @@ const Trending = () => {
   const { results: shows } = useSelector((state) => state.trending.trending);
 
   return (
-    <aside className="flex flex-col mt-10 mx-10 lg:ml-0">
+    <aside className="flex flex-col mt-10 mx-5 lg:ml-0">
       <div className="container-fluid flex flex-row justify-between xl:container">
         <div className="flex flex-row">
           <PlayButton />


### PR DESCRIPTION
## Changes in this pull request
> In this pull request I
- Reduced the `left` and `right` margins for the Trending component on Mobile and Tablet devices